### PR TITLE
Setup improvements: download code and environment configuration

### DIFF
--- a/bin/setup-tests.sh
+++ b/bin/setup-tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Download the selenium JAR
+SELENIUM_VERSION=2.41.0
+SELENIUM_MINOR_VERSION=2.41
+
+LOCAL_SELENIUM=vendor/selenium-server-standalone-$SELENIUM_VERSION.jar
+
+mkdir -p vendor
+
+if [ ! -e $LOCAL_SELENIUM ]
+then
+    wget -O $LOCAL_SELENIUM \
+	https://selenium-release.storage.googleapis.com/$SELENIUM_MINOR_VERSION/selenium-server-standalone-$SELENIUM_VERSION.jar
+fi
+
+# Check that the Chrome driver is present for Selenium
+command -v chromedriver >/dev/null 2>&1
+CHECK_RESULT=$?
+
+if [ $CHECK_RESULT != 0 ]
+then
+	echo 'Please install chromedriver for your os'
+	exit 1
+fi

--- a/create-runner.js
+++ b/create-runner.js
@@ -9,6 +9,12 @@ var counts = {
 
 module.exports = function (mocha) {
   var runner = mocha.run(function () {
+
+    if(!(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY)) {
+      // Bail out if we haven't defined any SauceLabs credentials
+      return;
+    }
+
     // Notify Sauce Labs on whether the suite passed or failed
     var hasPassed = counts.fail === 0;
     Q.ninvoke(request, 'put', {


### PR DESCRIPTION
This abstracts some of the changes I made in the curly quotes plugin and drops them in the test harness so they can be shared across the plugins.

The setup tests script is virtually the same as the initial version except for a more explicit check for the presence of the Chromedriver.

If also made the SauceLabs reporting conditional on the authorisation being present in the environment as otherwise the test suite blows up with an error right at the end.
