### PR TITLE
Add a whenPastingHTMLOf helper for testing paste

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -107,6 +107,30 @@ exports.whenInsertingHTMLOf = function (content, fn) {
   });
 };
 
+exports.whenPastingHTMLOf = function (content, fn) {
+  exports.when('content of "' + content + '" is pasted', function () {
+    beforeEach(function() {
+      return exports.driver.executeScript(function (content) {
+
+        // We need to use a fake paste event because Chrome Webdriver doesn't support simulated Ctrl+V
+        var mockEvent = new window.CustomEvent('paste', { bubbles: true });
+        mockEvent.clipboardData = {};
+        mockEvent.clipboardData.types = ['text/html'];
+        mockEvent.clipboardData.getData = function () {
+          return content;
+        };
+
+        var range = window.document.createRange();
+        range.selectNodeContents(window.scribe.el);
+        var selection = window.document.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+        window.scribe.el.dispatchEvent(mockEvent);
+      }, content);
+    });
+    fn();
+  });
+};
 
 // DOM helper
 exports.insertCaretPositionMarker = function () {


### PR DESCRIPTION
This is a prerequisite to tests for guardian/scribe#241. It creates a test helper that has the same signature as `whenInsertingHtmlOf` but inserts HTML via a simulated paste event, in order to exercise the paste formatting functionality added in guardian/scribe#241.

I have some vague forward-compatibility concerns about using a faked paste event here, but unfortunately the common Selenium approach of copying and pasting via keyboard commands doesn't behave in Chrome due to https://code.google.com/p/chromedriver/issues/detail?id=30 .

(this replaces https://github.com/guardian/scribe-test-harness/pull/9 which didn't behave in Chrome)