### PR TITLE
Paste helper: simplify clipboard definition

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+export BROWSER_NAME=${BROWSER_NAME:=chrome}
+
+export TEST_SERVER_PORT=${TEST_SERVER_PORT:=8880}
+
 ./node_modules/scribe-test-harness/node_modules/.bin/webdriver-manager update;
 
 ./node_modules/scribe-test-harness/node_modules/.bin/http-server -p $TEST_SERVER_PORT --silent &

--- a/helpers.js
+++ b/helpers.js
@@ -114,10 +114,11 @@ exports.whenPastingHTMLOf = function (content, fn) {
 
         // We need to use a fake paste event because Chrome Webdriver doesn't support simulated Ctrl+V
         var mockEvent = new window.CustomEvent('paste', { bubbles: true });
-        mockEvent.clipboardData = {};
-        mockEvent.clipboardData.types = ['text/html'];
-        mockEvent.clipboardData.getData = function () {
-          return content;
+        mockEvent.clipboardData = {
+          types: ['text/html'],
+          getData: function () {
+            return content;
+          }
         };
 
         var range = window.document.createRange();
@@ -125,6 +126,7 @@ exports.whenPastingHTMLOf = function (content, fn) {
         var selection = window.document.getSelection();
         selection.removeAllRanges();
         selection.addRange(range);
+        
         window.scribe.el.dispatchEvent(mockEvent);
       }, content);
     });


### PR DESCRIPTION
We were having an issue with an undefined error in Chrome for the types property. There's no need to build up the definition really so I think change simplifies the code and gets rid of the error.