### PR TITLE
Selenium: upgrade to 2.45

### DIFF
--- a/bin/setup-tests.sh
+++ b/bin/setup-tests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Download the selenium JAR
-SELENIUM_VERSION=2.41.0
-SELENIUM_MINOR_VERSION=2.41
+SELENIUM_VERSION=2.45.0
+SELENIUM_MINOR_VERSION=2.45
 
 LOCAL_SELENIUM=vendor/selenium-server-standalone-$SELENIUM_VERSION.jar
 

--- a/helpers.js
+++ b/helpers.js
@@ -255,7 +255,7 @@ if (local) {
   before(function () {
     // Note: you need to run from the root of the project
     // TODO: path.resolve
-    server = new SeleniumServer('./vendor/selenium-server-standalone-2.41.0.jar', {
+    server = new SeleniumServer('./vendor/selenium-server-standalone-2.45.0.jar', {
       port: 4444
     });
 


### PR DESCRIPTION
This should (sort of) fix local test running for Firefox 33 and later.

I have got FF tests running but I am still getting an occasional timeout failure. Still this is better than nothing for local development.