### PR TITLE
Configure selenium version on path and auto download .jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+vendor/*

--- a/helpers.js
+++ b/helpers.js
@@ -4,6 +4,9 @@ var Q = require('q');
 var SeleniumServer = require('selenium-webdriver/remote').SeleniumServer;
 var webdriver = require('selenium-webdriver');
 
+var SELENIUM_VERSION = process.env.SELENIUM_VERSION || 2.41.0;
+var seleniumPath = './vendor/selenium-server-standalone-' + SELENIUM_VERSION + '.jar';
+
 exports.given = function () {
   var args = Object.create(arguments);
   args[0] = 'given ' + args[0];
@@ -126,7 +129,7 @@ exports.whenPastingHTMLOf = function (content, fn) {
         var selection = window.document.getSelection();
         selection.removeAllRanges();
         selection.addRange(range);
-        
+
         window.scribe.el.dispatchEvent(mockEvent);
       }, content);
     });
@@ -255,7 +258,7 @@ if (local) {
   before(function () {
     // Note: you need to run from the root of the project
     // TODO: path.resolve
-    server = new SeleniumServer('./vendor/selenium-server-standalone-2.41.0.jar', {
+    server = new SeleniumServer(seleniumPath, {
       port: 4444
     });
 

--- a/helpers.js
+++ b/helpers.js
@@ -1,11 +1,33 @@
+var path = require('path');
+var fs = require('fs');
 var assign = require('lodash-node/modern/objects/assign');
 var contains = require('lodash-node/modern/collections/contains');
 var Q = require('q');
 var SeleniumServer = require('selenium-webdriver/remote').SeleniumServer;
 var webdriver = require('selenium-webdriver');
+var execSync = require('execsync');
+var mkdirp = require('mkdirp');
 
-var SELENIUM_VERSION = process.env.SELENIUM_VERSION || 2.41.0;
-var seleniumPath = './vendor/selenium-server-standalone-' + SELENIUM_VERSION + '.jar';
+var SELENIUM_VERSION = process.env.SELENIUM_VERSION || "2.41.0";
+var SELENIUM_MINOR_VERSION = SELENIUM_VERSION.substring(0, 4);
+var vendorPath = path.resolve(process.cwd(), 'vendor');
+//if we do not have a vendor folder create one
+if (!fs.existsSync(vendorPath)) {
+  mkdirp.sync(vendorPath);
+}
+
+//look for the selenium jar
+var seleniumPath = vendorPath + '/selenium-server-standalone-' + SELENIUM_VERSION + '.jar';
+//if selenium jar is not present download it
+if (!fs.existsSync(seleniumPath)) {
+  var command = 'wget -O vendor/selenium-server-standalone-' + SELENIUM_VERSION + '.jar '
+              + 'https://selenium-release.storage.googleapis.com/' + SELENIUM_MINOR_VERSION + '/selenium-server-standalone-' + SELENIUM_VERSION + '.jar';
+  console.log('Downloading selenium driver, this may take a while');
+  execSync(command);
+}
+
+
+
 
 exports.given = function () {
   var args = Object.create(arguments);

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "scribe-test-harness",
   "version": "0.0.17",
   "dependencies": {
+    "execsync": "0.0.6",
+    "http-server": "^0.7.3",
     "lodash-node": "~2.4.1",
+    "mkdirp": "^0.5.0",
     "mocha": "~1.18.2",
     "q": "~1.0.0",
     "request": "~2.33.0",
     "selenium-webdriver": "~2.41.0",
-    "http-server": "^0.7.3",
     "webdriver-manager": "^1.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes https://github.com/guardian/scribe-test-harness/issues/17 and https://github.com/guardian/scribe-test-harness/issues/16

Will allow you to change selenium version by using: 

`export SELENIUM_VERSION=2.41.0`

Will also download the binary to `./vendor/selenium-server-standalone-{SELENIUM_DRIVER_VERSION}.jar` auto magically.