### PR TITLE
Revert "See https://github.com/guardian/scribe/pull/390/files"

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -74,7 +74,7 @@ exports.initializeScribe = function (scribeModuleID, options) {
 
 function setContent(html) {
   return exports.driver.executeScript(function (html) {
-    window.scribe.setContent(html.replace(/\|/g, '<em [^>]*class="scribe-marker"[^>]*></em>'));
+    window.scribe.setContent(html.replace(/\|/g, '<em class="scribe-marker"></em>'));
   }, html);
 }
 


### PR DESCRIPTION
Reverts guardian/scribe-test-harness#23

This change broke the integration tests in _scribe-plugin-noting_ as it causes markers to be replaced by `[^>]*`.
<img width="675" alt="screen shot 2015-07-03 at 14 38 13" src="https://cloud.githubusercontent.com/assets/1936213/8500138/2d4385fc-2191-11e5-9779-318b11f57434.png">


@bradvogel I'm not quite sure what the intended behaviour was. Feel free to make another PR and we can get it in.