### PR TITLE
Remove deprecated `execsync` dependency

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -5,7 +5,7 @@ var contains = require('lodash-node/modern/collections/contains');
 var Q = require('q');
 var SeleniumServer = require('selenium-webdriver/remote').SeleniumServer;
 var webdriver = require('selenium-webdriver');
-var execSync = require('execsync');
+var execSync = require('child_process').execSync
 var mkdirp = require('mkdirp');
 
 var SELENIUM_VERSION = process.env.SELENIUM_VERSION || "2.46.0";

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.24",
   "description": "Utility functions for testing the Scribe editor and its associated plugins",
   "dependencies": {
-    "execsync": "0.0.6",
     "http-server": "^0.7.3",
     "lodash-node": "~2.4.1",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
Third party `execsync` module can't be installed on Node 0.12+ plus Node has native execSync since 0.12 anyway. This make this module unusable on node 0.10.x but that's probably OK. See #26 
